### PR TITLE
Correct handling of 24-hour of 22:xx or 23:xx

### DIFF
--- a/petclock.asm
+++ b/petclock.asm
@@ -311,16 +311,20 @@ UpdateClock
 
                 cmp #'3'                ; If the ONES digit is < 3, nothing to do
                 bcc +
-                dec HourTens            ; But otherwise we back up 12 hours
+BackUpTwelve    dec HourTens            ; But otherwise we back up 12 hours
 
                 dec HourDigits
                 dec HourDigits
 ZeroInTens      rts
 
-TwoInTens       lda #'0'                ; To go back 12 hours we go back 20 in the
+TwoInTens       cmp #'2'                ; If Ones digit is < 2, subtract 20 and add 8
+		bcc AddEight            ; Otherwise, backup 10 and backup 2 hours
+		jmp BackUpTwelve
+		
+AddEight        lda #'0'                ; To go back 12 hours we zero the
                 sta HourTens            ;  tens portion and add 8 to the digits
                 lda HourDigits
-                clc
+	        clc
                 adc #8
                 sta HourDigits
                 rts


### PR DESCRIPTION
Hi Dave,

I was not able to actually compile or test this code.
I apologize for that, but will look for a working toolchain to see if I can validate this code.

It looks to my mental 6502 processor that there's a bug in handling hours starting with 22 or 23. This code attempts to correctly handle those, but I don't have a working toolchain to verify that just yet. I will poke around and see if I can find one.